### PR TITLE
Removing double error messages when validating attribute and attribute_id

### DIFF
--- a/lib/rails2.rb
+++ b/lib/rails2.rb
@@ -26,11 +26,14 @@ module Perfectline
           end
 
           if target_class.nil? or !target_class.exists?(value)
-            record.errors.add(attribute, options[:message], :default => "does not exist")
+            errors = [attribute]
 
             # add the error on both :relation and :relation_id
             if options[:both]
               normalized = attribute.to_s.ends_with?("_id") ? normalized : "#{attribute}_id"
+              errors.push(normalized) unless errors.include? attribute
+            end
+            errors.each do | error |
               record.errors.add(normalized, options[:message], :default => "does not exist")
             end
           end
@@ -39,3 +42,4 @@ module Perfectline
     end
   end
 end
+

--- a/lib/rails3.rb
+++ b/lib/rails3.rb
@@ -35,12 +35,15 @@ module Perfectline
           end
 
           if value.nil? or target_class.nil? or !target_class.exists?(value)
-            record.errors.add(attribute, options[:message], :message => "does not exist")
+             errors = [attribute]
 
             # add the error on both :relation and :relation_id
             if options[:both]
               normalized = attribute.to_s.ends_with?("_id") ? normalized : "#{attribute}_id"
-              record.errors.add(normalized, options[:message], :message => "does not exist")
+              errors.push(normalized) unless errors.include? attribute
+            end
+            errors.each do | error |
+              record.errors.add(normalized, options[:message], :default => "does not exist")
             end
           end
         end
@@ -55,3 +58,4 @@ module Perfectline
     end
   end
 end
+


### PR DESCRIPTION
Adding the error message twice can make users think that something is wrong with the server. It aggregates no value to the customer.
