### PR TITLE
add support for :both => :foreign_key_only

### DIFF
--- a/lib/rails3.rb
+++ b/lib/rails3.rb
@@ -35,7 +35,11 @@ module Perfectline
           end
 
           if value.nil? or target_class.nil? or !target_class.exists?(value)
-            errors = [attribute]
+            errors = []
+
+            unless options[:both]==:foreign_key_only
+              errors.push(attribute)
+            end
 
             # add the error on both :relation and :relation_id
             if options[:both]


### PR DESCRIPTION
This commit adds support for setting the :both option to :foreign_key_only to the Rails3 code.   It doesn't add it to the README, the other versions or to the tests, which should be done.

I'm not particularly wedded to the API I chose for this feature, but the API I chose has the advantage of moderate backwards compatibility.
