### PR TITLE
Allow new objects to pass validation

### DIFF
--- a/lib/rails2.rb
+++ b/lib/rails2.rb
@@ -6,6 +6,7 @@ module Perfectline
         options = attribute_names.extract_options!.symbolize_keys
         options[:message] ||= :existence
         options[:both]    = true unless options.key?(:both)
+        options[:allow_new] = false unless options.key?(:allow_new)
 
         validates_each(attribute_names, options) do |record, attribute, value|
           normalized  = attribute.to_s.sub(/_id$/, "").to_sym
@@ -25,7 +26,13 @@ module Perfectline
             target_class = association.klass
           end
 
-          if target_class.nil? or !target_class.exists?(value)
+          if options[:allow_new]
+            exists = value.new_record? or target_class.exists?(value)
+          else
+            exists = target_class.exists?(value)
+          end
+
+          if target_class.nil? or !exists
             errors = [attribute]
 
             # add the error on both :relation and :relation_id

--- a/lib/rails3.rb
+++ b/lib/rails3.rb
@@ -13,6 +13,7 @@ module Perfectline
           # set the default message if its unspecified
           options[:message] ||= :existence
           options[:both]    = true unless options.key?(:both)
+          options[:allow_new] = false unless options.key?(:allow_new)
           super(options)
         end
 
@@ -34,7 +35,7 @@ module Perfectline
             target_class = association.klass
           end
 
-          if value.nil? || target_class.nil? || !target_class.exists?(value)
+          if value.nil? || target_class.nil? || !exists?(target_class, value)
             errors = [attribute]
 
             # add the error on both :relation and :relation_id
@@ -53,6 +54,14 @@ module Perfectline
             errors.each do |error|
               record.errors.add(error, options[:message], :message => messages)
             end
+          end
+        end
+
+        def exists?(target_class, value)
+          if options[:allow_new]
+            value.new_record? or target_class.exists?(value)
+          else
+            target_class.exists?(value)
           end
         end
       end


### PR DESCRIPTION
There are definitely use cases for validating an object where the associated object has not yet been saved (perhaps I am creating both objects at the same time). This PR adds a `allow_new` (default: `false`) option to the validation which if `true` will allow new objects to pass existence validation.
