### PR TITLE
Fix gemspec

### DIFF
--- a/validates_existence.gemspec
+++ b/validates_existence.gemspec
@@ -15,14 +15,11 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files = [
     "README.markdown"
   ]
-  s.files = [
-    "README.markdown",
-    "install.rb",
-    "lib/rails2.rb",
-    "lib/rails3.rb",
-    "lib/validates_existence.rb",
-    "rails/init.rb"
-  ]
+
+  s.files         = `git ls-files`.split($/)
+  s.executables   = s.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
+  s.test_files    = s.files.grep(%r{^(test|spec|features)/})
+
   s.homepage = "http://github.com/perfectline/validates_existence/tree/master"
   s.require_paths = ["lib"]
   s.rubygems_version = "1.8.24"


### PR DESCRIPTION
The gemspec wasn't updated to match the restructured codebase. Update to use `git ls-files` so that a file list doesn't need to be hardcoded.
