### PR TITLE
Use foreign_key for ActiveRecord 4.0.0

### DIFF
--- a/lib/validates_existence.rb
+++ b/lib/validates_existence.rb
@@ -36,7 +36,7 @@ module Perfectline
 
             # add the error on both :relation and :relation_id
             if options[:both]
-              if ActiveRecord::VERSION::MAJOR >= 3 && ActiveRecord::VERSION::MINOR >= 1
+              if ActiveRecord::VERSION::MAJOR > 3 || (ActiveRecord::VERSION::MAJOR == 3 && ActiveRecord::VERSION::MINOR >= 1)
                 foreign_key = association.foreign_key
               else
                 foreign_key = association.primary_key_name


### PR DESCRIPTION
The previous fix didn't work for 4.0.0, since it always checked the minor version.
