### PR TITLE
Pass in the id to the #exists? method of ActiveRecord::Base instead of the entire object

### DIFF
--- a/lib/validates_existence.rb
+++ b/lib/validates_existence.rb
@@ -68,7 +68,7 @@ module Perfectline
         end
 
         def exists?(target_class, value)
-          (options[:allow_new] && value.new_record?) || target_class.exists?(value)
+          (options[:allow_new] && value.new_record?) || (value.persisted? && target_class.exists?(value.id))
         end
       end
     end


### PR DESCRIPTION
As noticed in #28, the #exists? method of ActiveRecord::Base now only wants the id. This closes #28.
